### PR TITLE
Update PKGBUILD

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -1,43 +1,33 @@
 # Maintainer: William Bonnaventure <william.bonnaventure@gmail.com>
-pkgname=MagicFountain
+# Maintainer: ZeroDot1 <zerodot1@bk.ru>
+pkgname=magicfountain
 pkgver=1.0.0
 pkgrel=1
-epoch=
-pkgdesc="A screenwriter"
-arch=(any)
+pkgdesc="A Fountain syntax editor and viewer."
+arch=('any')
 url="https://github.com/Aztorius/magicfountain"
-license=('GPL')
+license=('GPL3')
 groups=()
-depends=('qt5-base>=5.7.0')
-makedepends=('qt5-base>=5.7.0')
-checkdepends=()
+depends=('qt5-base')
+makedepends=('qt5-base' 'git')
 optdepends=()
-provides=()
-conflicts=()
-replaces=()
-backup=()
-options=()
-install=
-changelog=
-source=("https://github.com/Aztorius/magicfountain/archive/$pkgver-alpha4.tar.gz")
-noextract=()
+source=("https://github.com/Aztorius/magicfountain/archive/${pkgver}-alpha4.tar.gz")
 md5sums=('4f7bda958f29a23fbfdd59980173a383')
-validpgpkeys=()
 
-prepare() {}
 
 build() {
-	cd "$pkgname-$pkgver"
-	qmake PREFIX=/usr
-	make
+	cd ${srcdir}/${pkgname}-${pkgver}
+	qmake PREFIX='/usr' \
+        LIBDIR='/usr/lib' 
+    make
 }
 
 check() {
-	cd "$pkgname-$pkgver"
-	make -k check
+	cd ${srcdir}/${pkgname}-${pkgver}
+	make -k check-alpha4
 }
 
 package() {
-	cd "$pkgname-$pkgver"
+	cd ${srcdir}/${pkgname}-${pkgver}
 	make DESTDIR="$pkgdir/" install
 }


### PR DESCRIPTION
A small update.
The build does not work.

```bash
$ makepkg -csi
==> Erstelle Paket: magicfountain 1.0.0-1 (Do 24. Aug 14:42:33 CEST 2017)
==> Prüfe Laufzeit-Abhängigkeiten...
==> Prüfe Buildtime-Abhängigkeiten...
==> Empfange Quellen...
  -> 1.0.0-alpha4.tar.gz gefunden
==> Überprüfe source Dateien mit md5sums...
    1.0.0-alpha4.tar.gz ... Durchgelaufen
==> Entpacke Quellen...
  -> Entpacke 1.0.0-alpha4.tar.gz mit bsdtar
==> Entferne existierendes $pkgdir/ Verzeichnis...
==> Beginne build()...
Usage: qmake [mode] [options] [files]

QMake has two modes, one mode for generating project files based on
some heuristics, and the other for generating makefiles. Normally you
shouldn't need to specify a mode, as makefile generation is the default
mode for qmake, but you may use this to test qmake on an existing project

Mode:
  -project       Put qmake into project file generation mode
                 In this mode qmake interprets files as files to
                 be built,
                 defaults to *; *; *; *.ts; *.xlf; *.qrc
                 Note: The created .pro file probably will 
                 need to be edited. For example add the QT variable to 
                 specify what modules are required.
  -makefile      Put qmake into makefile generation mode (default)
                 In this mode qmake interprets files as project files to
                 be processed, if skipped qmake will try to find a project
                 file in your current working directory

Warnings Options:
  -Wnone         Turn off all warnings; specific ones may be re-enabled by
                 later -W options
  -Wall          Turn on all warnings
  -Wparser       Turn on parser warnings
  -Wlogic        Turn on logic warnings (on by default)
  -Wdeprecated   Turn on deprecation warnings (on by default)

Options:
   * You can place any variable assignment in options and it will be *
   * processed as if it was in [files]. These assignments will be    *
   * processed before [files] by default.                            *
  -o file        Write output to file
  -d             Increase debug level
  -t templ       Overrides TEMPLATE as templ
  -tp prefix     Overrides TEMPLATE so that prefix is prefixed into the value
  -help          This help
  -v             Version information
  -early         All subsequent variable assignments will be
                 parsed right before default_pre.prf
  -before        All subsequent variable assignments will be
                 parsed right before [files] (the default)
  -after         All subsequent variable assignments will be
                 parsed after [files]
  -late          All subsequent variable assignments will be
                 parsed right after default_post.prf
  -norecursive   Don't do a recursive search
  -recursive     Do a recursive search
  -set <prop> <value> Set persistent property
  -unset <prop>  Unset persistent property
  -query <prop>  Query persistent property. Show all if <prop> is empty.
  -qtconf file   Use file instead of looking for qt.conf
  -cache file    Use file as cache           [makefile mode only]
  -spec spec     Use spec as QMAKESPEC       [makefile mode only]
  -nocache       Don't use a cache file      [makefile mode only]
  -nodepend      Don't generate dependencies [makefile mode only]
  -nomoc         Don't generate moc targets  [makefile mode only]
  -nopwd         Don't look for files in pwd [project mode only]
==> FEHLER: Ein Fehler geschah in build().
    Breche ab...
```