### PR TITLE
Update PKGBUILD

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -4,10 +4,9 @@ pkgname=magicfountain
 pkgver=1.0.0
 pkgrel=1
 pkgdesc="A Fountain syntax editor and viewer."
-arch=('any')
+arch=('i686' 'x86_64')
 url="https://github.com/Aztorius/magicfountain"
 license=('GPL3')
-groups=()
 depends=('qt5-base')
 makedepends=('qt5-base' 'git')
 optdepends=()
@@ -15,18 +14,12 @@ source=("https://github.com/Aztorius/magicfountain/archive/${pkgver}-alpha4.tar.
 md5sums=('4f7bda958f29a23fbfdd59980173a383')
 
 build() {
-	cd ${srcdir}/${pkgname}-${pkgver}
-	qmake PREFIX='/usr' \
-        LIBDIR='/usr/lib' magicfountain.pro
+	cd ${srcdir}/${pkgname}-${pkgver}-alpha4
+	qmake-qt5 
         make
 }
 
-check() {
-	cd ${srcdir}/${pkgname}-${pkgver}
-	make -k check-alpha4
-}
-
 package() {
-	cd ${srcdir}/${pkgname}-${pkgver}
+	cd ${srcdir}/${pkgname}-${pkgver}-alpha4
 	make DESTDIR="$pkgdir/" install
 }


### PR DESCRIPTION
It still does not work. 
Building Magic Fountain works, but the package is not complete.

## LOG:
```bash
$ makepkg -csi
==> Erstelle Paket: magicfountain 1.0.0-1 (Do 24. Aug 19:34:47 CEST 2017)
==> Prüfe Laufzeit-Abhängigkeiten...
==> Prüfe Buildtime-Abhängigkeiten...
==> Empfange Quellen...
  -> 1.0.0-alpha4.tar.gz gefunden
==> Überprüfe source Dateien mit md5sums...
    1.0.0-alpha4.tar.gz ... Durchgelaufen
==> Entpacke Quellen...
  -> Entpacke 1.0.0-alpha4.tar.gz mit bsdtar
==> Beginne build()...
Info: creating stash file /home/user/magicfountain-bin/src/magicfountain-1.0.0-alpha4/.qmake.stash
/usr/bin/uic mainwindow.ui -o ui_mainwindow.h
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o main.o main.cpp
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o mainwindow.o mainwindow.cpp
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o script.o script.cpp
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o block.o block.cpp
/usr/bin/rcc -name ressources ressources.qrc -o qrc_ressources.cpp
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o qrc_ressources.o qrc_ressources.cpp
g++ -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -dM -E -o moc_predefs.h /usr/lib/qt/mkspecs/features/data/dummy.cpp
/usr/bin/moc -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB --include ./moc_predefs.h -I/usr/lib/qt/mkspecs/linux-g++ -I/home/user/magicfountain-bin/src/magicfountain-1.0.0-alpha4 -I/usr/include/qt -I/usr/include/qt/QtPrintSupport -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtGui -I/usr/include/qt/QtCore -I/usr/include/c++/7.1.1 -I/usr/include/c++/7.1.1/x86_64-pc-linux-gnu -I/usr/include/c++/7.1.1/backward -I/usr/lib/gcc/x86_64-pc-linux-gnu/7.1.1/include -I/usr/local/include -I/usr/lib/gcc/x86_64-pc-linux-gnu/7.1.1/include-fixed -I/usr/include mainwindow.h -o moc_mainwindow.cpp
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt -isystem /usr/include/qt/QtPrintSupport -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -isystem /usr/include/libdrm -I. -I/usr/lib/qt/mkspecs/linux-g++ -o moc_mainwindow.o moc_mainwindow.cpp
g++ -Wl,-O1 -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -o MagicFountain main.o mainwindow.o script.o block.o qrc_ressources.o moc_mainwindow.o   -lQt5PrintSupport -lQt5Widgets -lQt5Gui -lQt5Core -lGL -lpthread 
==> Betrete fakeroot Umgebung...
==> Beginne package()...
make: Für das Ziel „install“ ist nichts zu tun.
==> Säubere Installation...
  -> Entferne libtool Dateien...
  -> Bereinige ungewollte Dateien...
  -> Entferne statische Bibliotheken...
  -> Entferne unnötige Symbole aus Binär-Dateien und Bibliotheken...
  -> Komprimiere Man-Pages und Info-Seiten...
==> Prüfe auf Paketierungsprobleme...
==> Erstelle Paket "magicfountain"...
  -> Erstelle .PKGINFO Datei...
  -> Erstelle .BUILDINFO Datei...
  -> Erstelle .MTREE-Datei...
  -> Komprimiere Paket... 
==> Verlasse fakeroot Umgebung.
==> Beendete Erstellung: magicfountain 1.0.0-1 (Do 24. Aug 19:35:01 CEST 2017)
==> Installiere Paket magicfountain mit pacman -U...
[sudo] Passwort für user: 
Lade Pakete...
Warnung: magicfountain-1.0.0-1 ist aktuell -- Reinstalliere
Löse Abhängigkeiten auf...
Suche nach in Konflikt stehenden Paketen...

Pakete (1) magicfountain-1.0.0-1

Gesamtgröße der installierten Pakete:  0,00 MiB
Größendifferenz der Aktualisierung:  0,00 MiB

:: Installation fortsetzen? [J/n] 
(1/1) Prüfe Schlüssel im Schlüsselring             [######################] 100%
(1/1) Überprüfe Paket-Integrität                   [######################] 100%
(1/1) Lade Paket-Dateien                           [######################] 100%
(1/1) Prüfe auf Dateikonflikte                     [######################] 100%
(1/1) Überprüfe verfügbaren Festplattenspeicher    [######################] 100%
:: Verarbeite Paketänderungen...
(1/1) Installiere magicfountain                    [######################] 100%
==> Räume auf...
```
```
# Generated by makepkg 5.0.2
# using fakeroot version 1.21
# Thu Aug 24 17:35:01 UTC 2017
pkgname = magicfountain
pkgver = 1.0.0-1
pkgdesc = A Fountain syntax editor and viewer.
url = https://github.com/Aztorius/magicfountain
builddate = 1503596101
packager = Unknown Packager
size = 4096
arch = x86_64
license = GPL3
depend = qt5-base
makedepend = qt5-base
makedepend = git
```

Screenshot: 
![bildschirmfoto_2017-08-24_19-43-43](https://user-images.githubusercontent.com/28985171/29680447-dd079ae6-8904-11e7-94b1-e21dccc99814.png)

